### PR TITLE
feat: colored terminal output (ANSI) for rich/typer etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,43 @@ extra_javascript = ["javascripts/termynal.js"]
 include_assets = false
 ```
 
+### Colored output (rich, typer, …)
+
+Tools like [rich](https://github.com/Textualize/rich) and
+[typer](https://github.com/fastapi/typer) emit ANSI color sequences. Enable the
+`ansi` option to convert those sequences into colored HTML instead of escaping
+them. It requires the optional `ansi2html` dependency:
+
+```
+pip install 'termynal[ansi]'
+```
+
+Then turn it on globally:
+
+```yaml
+[...]
+plugins:
+  - termynal:
+      ansi: true
+[...]
+```
+
+or per block:
+
+````markdown
+<!-- termynal: ansi: true -->
+
+```
+$ python app.py
+```
+````
+
+Paste the raw ANSI output into the code block (e.g. capture it with
+`rich.console.Console(force_terminal=True)`, `FORCE_COLOR=1`, or typer's
+`--color`). Each output line is converted independently with inline styles, so
+no extra CSS is needed. Colors render on output lines; typed command lines are
+shown as plain text by the animation.
+
 ## Credits
 
 Thanks [ines](https://github.com/ines/termynal)

--- a/README.md
+++ b/README.md
@@ -114,59 +114,22 @@ include_assets = false
 ### Colored output (rich, typer, …)
 
 Tools like [rich](https://github.com/Textualize/rich) and
-[typer](https://github.com/fastapi/typer) emit ANSI color sequences. Enable the
-`ansi` option to convert those sequences into colored HTML instead of escaping
-them. It requires the optional `ansi2html` dependency:
-
-```
-pip install 'termynal[ansi]'
-```
-
-Then turn it on globally:
-
-```yaml
-[...]
-plugins:
-  - termynal:
-      ansi: true
-[...]
-```
-
-or per block:
+[typer](https://github.com/fastapi/typer) emit ANSI color sequences. Set
+`ansi: true` to render them as colored HTML instead of escaping them (requires
+the optional dependency: `pip install 'termynal[ansi]'`):
 
 ````markdown
 <!-- termynal: ansi: true -->
 
 ```
-$ python app.py
+$ uv -h
 ```
 ````
 
-Paste the raw ANSI output into the code block (e.g. capture it with
-`rich.console.Console(force_terminal=True)`, `FORCE_COLOR=1`, or typer's
-`--color`). Each output line is converted independently with inline styles, so
-no extra CSS is needed. Colors render on output lines; typed command lines are
-shown as plain text by the animation.
-
-The 16 base ANSI colors are mapped through a palette. The default is `xterm`
-(the canonical reference terminal palette); other options are `ansi2html`,
-`osx`, `osx-basic`, `osx-solid-colors`, `dracula`, `solarized`, and
-`mint-terminal`. 256-color and 24-bit truecolor sequences are always mapped
-faithfully, regardless of the scheme.
-
-```yaml
-[...]
-plugins:
-  - termynal:
-      ansi: true
-      ansi_scheme: xterm
-      ansi_dark_bg: true
-[...]
-```
-
-> Tip: for pixel-exact colors, tell the tool to emit 24-bit color (e.g.
-> `rich.console.Console(color_system="truecolor")`) — the base-color palette is
-> then bypassed entirely.
+Paste the raw colored output into the block (capture it with `FORCE_COLOR=1` or
+rich's `force_terminal=True`). Colors render on output lines; typed commands
+stay plain. The palette (`ansi_scheme`) and other options are documented in
+[Configuration](https://termynal.github.io/termynal.py/configuration/).
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ include_assets = true
 title = "bash"
 buttons = "macos"
 prompt_literal_start = ["$"]
+ansi = false
 ```
 
 You can override default assets with your own files:

--- a/README.md
+++ b/README.md
@@ -147,6 +147,26 @@ Paste the raw ANSI output into the code block (e.g. capture it with
 no extra CSS is needed. Colors render on output lines; typed command lines are
 shown as plain text by the animation.
 
+The 16 base ANSI colors are mapped through a palette. The default is `xterm`
+(the canonical reference terminal palette); other options are `ansi2html`,
+`osx`, `osx-basic`, `osx-solid-colors`, `dracula`, `solarized`, and
+`mint-terminal`. 256-color and 24-bit truecolor sequences are always mapped
+faithfully, regardless of the scheme.
+
+```yaml
+[...]
+plugins:
+  - termynal:
+      ansi: true
+      ansi_scheme: xterm
+      ansi_dark_bg: true
+[...]
+```
+
+> Tip: for pixel-exact colors, tell the tool to emit 24-bit color (e.g.
+> `rich.console.Console(color_system="truecolor")`) — the base-color palette is
+> then bypassed entirely.
+
 ## Credits
 
 Thanks [ines](https://github.com/ines/termynal)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,5 +1,7 @@
 # Configuration
 
+## Options
+
 | **name**             | **default** |                        |
 |----------------------|-------------|------------------------|
 | title                | `"bash"`    |                        |
@@ -11,6 +13,10 @@
 | ansi                 | `false`     | render ANSI colors as HTML |
 | ansi_scheme          | `"xterm"`   | `ansi2html`, `dracula`, `mint-terminal`, `osx`, `osx-basic`, `osx-solid-colors`, `solarized`, `xterm` |
 | ansi_dark_bg         | `true`      | dark-background palette variant |
+
+## Global configuration
+
+Set defaults for every block in `mkdocs.yml`:
 
 ```yaml
 plugins:
@@ -27,7 +33,11 @@ plugins:
       ansi_dark_bg: true
 ```
 
+## Per-block overrides
+
 You can override configurations for each block. If you set a part of the settings, the other part will be set to the default value from `mkdocs.yml`.
+
+### Custom prompt and buttons
 
 `<!-- termynal: {"prompt_literal_start": ["$", ">>>", "PS >"], title: powershell, buttons: windows} -->`
 
@@ -45,7 +55,7 @@ PS > python
 >>> import json
 ```
 
-## Colored output
+### Colored output
 
 With `ansi: true` (requires `pip install 'termynal[ansi]'`), ANSI color
 sequences from tools like [rich](https://github.com/Textualize/rich) and

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,6 +8,9 @@
 | include_assets       | `false`     |                        |
 | assets_override_css  | `null`      | path to custom css file |
 | assets_override_js   | `null`      | path to custom js file  |
+| ansi                 | `false`     | render ANSI colors as HTML |
+| ansi_scheme          | `"xterm"`   | `ansi2html`, `dracula`, `mint-terminal`, `osx`, `osx-basic`, `osx-solid-colors`, `solarized`, `xterm` |
+| ansi_dark_bg         | `true`      | dark-background palette variant |
 
 ```yaml
 plugins:
@@ -19,6 +22,9 @@ plugins:
       include_assets: false
       assets_override_css: null
       assets_override_js: null
+      ansi: false
+      ansi_scheme: xterm
+      ansi_dark_bg: true
 ```
 
 You can override configurations for each block. If you set a part of the settings, the other part will be set to the default value from `mkdocs.yml`.
@@ -38,3 +44,28 @@ PS > python
 PS > python
 >>> import json
 ```
+
+## Colored output
+
+With `ansi: true` (requires `pip install 'termynal[ansi]'`), ANSI color
+sequences from tools like [rich](https://github.com/Textualize/rich) and
+[typer](https://github.com/fastapi/typer) are rendered as colored HTML instead
+of being escaped. Paste the raw colored output into the block:
+
+<!-- termynal: ansi: true -->
+
+```
+$ uv -h
+An extremely fast Python package manager.
+
+[1m[32mUsage:[0m [1m[36muv[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
+
+[1m[32mCommands:[0m
+  [1m[36mrun[0m      Run a command or script
+  [1m[36minit[0m     Create a new project
+  [1m[36madd[0m      Add dependencies to the project
+  [1m[36mremove[0m   Remove dependencies from the project
+  [1m[36msync[0m     Update the project's environment
+  [1m[36mlock[0m     Update the project's lockfile
+```
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dev = [
     "types-pyyaml >= 6.0",
 ]
 docs = [
+    "ansi2html >= 1.8",
     "markdown-include >= 0.8",
     "mkdocs >= 1.6",
     "mkdocs-material >= 9.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,11 @@ Documentation = "https://termynal.github.io/termynal.py/"
 
 [project.optional-dependencies]
 mkdocs = ["mkdocs >= 1.4"]
+ansi = ["ansi2html >= 1.8"]
 
 [dependency-groups]
 dev = [
+    "ansi2html >= 1.8",
     "mypy >= 1.13.0",
     "pytest >= 7.4",
     "pytest-cov >= 4.1",

--- a/termynal/markdown.py
+++ b/termynal/markdown.py
@@ -39,6 +39,7 @@ class Config(NamedTuple):
     include_assets: bool
     assets_override_css: Optional[str]
     assets_override_js: Optional[str]
+    ansi: bool
 
 
 class Command(NamedTuple):
@@ -81,6 +82,28 @@ def escape(txt: str) -> str:
     txt = txt.replace(">", "&gt;")
     txt = txt.replace('"', "&quot;")
     return txt  # noqa:RET504
+
+
+def ansi_escape(code: str) -> str:
+    """Escape ``code`` while turning ANSI color sequences into HTML spans.
+
+    Each line is converted independently so color spans are always balanced
+    within a line (termynal renders every output line as its own element).
+    Literal text is HTML-escaped by ``ansi2html`` itself, so the result is a
+    drop-in replacement for :func:`escape` when ANSI support is enabled.
+    """
+    try:
+        from ansi2html import Ansi2HTMLConverter
+    except ImportError as exc:  # pragma:no cover
+        raise ImportError(
+            "ANSI support requires the 'ansi2html' package. "
+            "Install it with: pip install 'termynal[ansi]'",
+        ) from exc
+
+    converter = Ansi2HTMLConverter(inline=True)
+    return "\n".join(
+        converter.convert(line, full=False) for line in code.split("\n")
+    )
 
 
 def remove_spaces(code: str, spaces: str) -> str:
@@ -140,6 +163,11 @@ def parse_config_from_dict(
     if assets_override_js is not None:
         assets_override_js = str(assets_override_js).strip() or None
 
+    ansi_default = default.ansi if default else False
+    ansi = config.get("ansi", ansi_default)
+    if not isinstance(ansi, bool):
+        ansi = ansi_default
+
     return Config(
         title=str(config.get("title", default.title if default else "bash")),
         prompt_literal_start=list(
@@ -152,6 +180,7 @@ def parse_config_from_dict(
         include_assets=include_assets,
         assets_override_css=assets_override_css,
         assets_override_js=assets_override_js,
+        ansi=ansi,
     )
 
 
@@ -320,8 +349,9 @@ class TermynalPreprocessor(Preprocessor):
                     if config:
                         termynal = Termynal(config)
 
+                escaper = ansi_escape if termynal.config.ansi else escape
                 converted_code = add_spaces(
-                    termynal.convert(escape(remove_spaces(code, spaces))),
+                    termynal.convert(escaper(remove_spaces(code, spaces))),
                     spaces,
                 )
                 text = f"{text[:start]}\n{converted_code}\n{text[end:]}"
@@ -367,6 +397,12 @@ class TermynalExtension(Extension):
                 "",
                 "Path to a custom JS file to inline instead of the built-in "
                 "termynal.js when include_assets is true.",
+            ],
+            "ansi": [
+                False,
+                "Convert ANSI color sequences (e.g. from rich/typer output) into "
+                "HTML spans instead of escaping them. Requires the 'ansi2html' "
+                "package. Default: False",
             ],
         }
 

--- a/termynal/markdown.py
+++ b/termynal/markdown.py
@@ -106,20 +106,27 @@ def ansi_escape(
 ) -> str:
     """Escape ``code``, turning ANSI color sequences into HTML spans.
 
-    Converted per line so spans stay balanced within each terminal line.
+    Lines without an escape sequence are passed through :func:`escape`
+    unchanged, so enabling ``ansi`` does not alter ANSI-free output. Lines that
+    do contain ANSI are converted individually, keeping spans balanced per line.
     """
-    try:
-        from ansi2html import Ansi2HTMLConverter
-    except ImportError as exc:  # pragma:no cover
-        raise ImportError(
-            "ANSI support requires the 'ansi2html' package. "
-            "Install it with: pip install 'termynal[ansi]'",
-        ) from exc
-
-    converter = Ansi2HTMLConverter(inline=True, scheme=scheme, dark_bg=dark_bg)
-    return "\n".join(
-        converter.convert(line, full=False) for line in code.split("\n")
-    )
+    converter = None
+    result = []
+    for line in code.split("\n"):
+        if "\x1b" not in line:
+            result.append(escape(line))
+            continue
+        if converter is None:
+            try:
+                from ansi2html import Ansi2HTMLConverter
+            except ImportError as exc:  # pragma:no cover
+                raise ImportError(
+                    "ANSI support requires the 'ansi2html' package. "
+                    "Install it with: pip install 'termynal[ansi]'",
+                ) from exc
+            converter = Ansi2HTMLConverter(inline=True, scheme=scheme, dark_bg=dark_bg)
+        result.append(converter.convert(line, full=False))
+    return "\n".join(result)
 
 
 def remove_spaces(code: str, spaces: str) -> str:
@@ -257,6 +264,12 @@ class Termynal:
         self.progress_literal_start = progress_literal_start
         self.comment_literal_start = comment_literal_start
 
+    def escape(self, code: str) -> str:
+        """Escape code, converting ANSI to spans when ``ansi`` is enabled."""
+        if self.config.ansi:
+            return ansi_escape(code, self.config.ansi_scheme, self.config.ansi_dark_bg)
+        return escape(code)
+
     def convert(self, code: str) -> str:
         """Converts bash code to termynal HTML.
 
@@ -377,16 +390,7 @@ class TermynalPreprocessor(Preprocessor):
                     if config:
                         termynal = Termynal(config)
 
-                cleaned = remove_spaces(code, spaces)
-                escaped = (
-                    ansi_escape(
-                        cleaned,
-                        termynal.config.ansi_scheme,
-                        termynal.config.ansi_dark_bg,
-                    )
-                    if termynal.config.ansi
-                    else escape(cleaned)
-                )
+                escaped = termynal.escape(remove_spaces(code, spaces))
                 converted_code = add_spaces(termynal.convert(escaped), spaces)
                 text = f"{text[:start]}\n{converted_code}\n{text[end:]}"
                 termynal = default_termynal

--- a/termynal/markdown.py
+++ b/termynal/markdown.py
@@ -32,6 +32,19 @@ class Buttons(str, Enum):
     WINDOWS = "windows"
 
 
+ANSI_SCHEMES = (
+    "ansi2html",
+    "dracula",
+    "mint-terminal",
+    "osx",
+    "osx-basic",
+    "osx-solid-colors",
+    "solarized",
+    "xterm",
+)
+DEFAULT_ANSI_SCHEME = "xterm"
+
+
 class Config(NamedTuple):
     title: str
     prompt_literal_start: Sequence[str]
@@ -40,6 +53,8 @@ class Config(NamedTuple):
     assets_override_css: Optional[str]
     assets_override_js: Optional[str]
     ansi: bool
+    ansi_scheme: str
+    ansi_dark_bg: bool
 
 
 class Command(NamedTuple):
@@ -84,13 +99,14 @@ def escape(txt: str) -> str:
     return txt  # noqa:RET504
 
 
-def ansi_escape(code: str) -> str:
-    """Escape ``code`` while turning ANSI color sequences into HTML spans.
+def ansi_escape(
+    code: str,
+    scheme: str = DEFAULT_ANSI_SCHEME,
+    dark_bg: bool = True,
+) -> str:
+    """Escape ``code``, turning ANSI color sequences into HTML spans.
 
-    Each line is converted independently so color spans are always balanced
-    within a line (termynal renders every output line as its own element).
-    Literal text is HTML-escaped by ``ansi2html`` itself, so the result is a
-    drop-in replacement for :func:`escape` when ANSI support is enabled.
+    Converted per line so spans stay balanced within each terminal line.
     """
     try:
         from ansi2html import Ansi2HTMLConverter
@@ -100,7 +116,7 @@ def ansi_escape(code: str) -> str:
             "Install it with: pip install 'termynal[ansi]'",
         ) from exc
 
-    converter = Ansi2HTMLConverter(inline=True)
+    converter = Ansi2HTMLConverter(inline=True, scheme=scheme, dark_bg=dark_bg)
     return "\n".join(
         converter.convert(line, full=False) for line in code.split("\n")
     )
@@ -168,6 +184,16 @@ def parse_config_from_dict(
     if not isinstance(ansi, bool):
         ansi = ansi_default
 
+    ansi_scheme_default = default.ansi_scheme if default else DEFAULT_ANSI_SCHEME
+    ansi_scheme = config.get("ansi_scheme", ansi_scheme_default)
+    if ansi_scheme not in ANSI_SCHEMES:
+        ansi_scheme = ansi_scheme_default
+
+    ansi_dark_bg_default = default.ansi_dark_bg if default else True
+    ansi_dark_bg = config.get("ansi_dark_bg", ansi_dark_bg_default)
+    if not isinstance(ansi_dark_bg, bool):
+        ansi_dark_bg = ansi_dark_bg_default
+
     return Config(
         title=str(config.get("title", default.title if default else "bash")),
         prompt_literal_start=list(
@@ -181,6 +207,8 @@ def parse_config_from_dict(
         assets_override_css=assets_override_css,
         assets_override_js=assets_override_js,
         ansi=ansi,
+        ansi_scheme=ansi_scheme,
+        ansi_dark_bg=ansi_dark_bg,
     )
 
 
@@ -349,11 +377,17 @@ class TermynalPreprocessor(Preprocessor):
                     if config:
                         termynal = Termynal(config)
 
-                escaper = ansi_escape if termynal.config.ansi else escape
-                converted_code = add_spaces(
-                    termynal.convert(escaper(remove_spaces(code, spaces))),
-                    spaces,
+                cleaned = remove_spaces(code, spaces)
+                escaped = (
+                    ansi_escape(
+                        cleaned,
+                        termynal.config.ansi_scheme,
+                        termynal.config.ansi_dark_bg,
+                    )
+                    if termynal.config.ansi
+                    else escape(cleaned)
                 )
+                converted_code = add_spaces(termynal.convert(escaped), spaces)
                 text = f"{text[:start]}\n{converted_code}\n{text[end:]}"
                 termynal = default_termynal
             else:
@@ -403,6 +437,16 @@ class TermynalExtension(Extension):
                 "Convert ANSI color sequences (e.g. from rich/typer output) into "
                 "HTML spans instead of escaping them. Requires the 'ansi2html' "
                 "package. Default: False",
+            ],
+            "ansi_scheme": [
+                DEFAULT_ANSI_SCHEME,
+                "Palette for the 16 base ANSI colors when ansi is enabled. One of: "
+                f"{', '.join(ANSI_SCHEMES)}. Default: '{DEFAULT_ANSI_SCHEME}'",
+            ],
+            "ansi_dark_bg": [
+                True,
+                "Use the dark-background palette variant when ansi is enabled. "
+                "Default: True",
             ],
         }
 

--- a/termynal/plugin.py
+++ b/termynal/plugin.py
@@ -19,6 +19,7 @@ class TermynalPluginConfig(base.Config):
     include_assets = c.Type(bool, default=False)
     assets_override_css = c.Optional(c.Type(str))
     assets_override_js = c.Optional(c.Type(str))
+    ansi = c.Type(bool, default=False)
 
 
 class TermynalPlugin(BasePlugin[TermynalPluginConfig]):

--- a/termynal/plugin.py
+++ b/termynal/plugin.py
@@ -20,6 +20,20 @@ class TermynalPluginConfig(base.Config):
     assets_override_css = c.Optional(c.Type(str))
     assets_override_js = c.Optional(c.Type(str))
     ansi = c.Type(bool, default=False)
+    ansi_scheme = c.Choice(
+        (
+            "ansi2html",
+            "dracula",
+            "mint-terminal",
+            "osx",
+            "osx-basic",
+            "osx-solid-colors",
+            "solarized",
+            "xterm",
+        ),
+        default="xterm",
+    )
+    ansi_dark_bg = c.Type(bool, default=True)
 
 
 class TermynalPlugin(BasePlugin[TermynalPluginConfig]):

--- a/termynal/plugin.py
+++ b/termynal/plugin.py
@@ -6,6 +6,8 @@ from mkdocs.config import base
 from mkdocs.config import config_options as c
 from mkdocs.plugins import BasePlugin
 
+from termynal.markdown import ANSI_SCHEMES, DEFAULT_ANSI_SCHEME
+
 if TYPE_CHECKING:  # pragma:no cover
     from mkdocs.config.defaults import MkDocsConfig
 
@@ -20,19 +22,7 @@ class TermynalPluginConfig(base.Config):
     assets_override_css = c.Optional(c.Type(str))
     assets_override_js = c.Optional(c.Type(str))
     ansi = c.Type(bool, default=False)
-    ansi_scheme = c.Choice(
-        (
-            "ansi2html",
-            "dracula",
-            "mint-terminal",
-            "osx",
-            "osx-basic",
-            "osx-solid-colors",
-            "solarized",
-            "xterm",
-        ),
-        default="xterm",
-    )
+    ansi_scheme = c.Choice(ANSI_SCHEMES, default=DEFAULT_ANSI_SCHEME)
     ansi_dark_bg = c.Type(bool, default=True)
 
 

--- a/tests/test_markdown_extension.py
+++ b/tests/test_markdown_extension.py
@@ -105,3 +105,35 @@ $ echo termynal
     assert ".termy { border: 1px solid red; }" in html
     assert "window.__termynal_override = true;" in html
     assert "data-terminal-control" not in html
+
+
+def test_ansi_output_is_converted_to_spans():
+    md = "<!-- termynal -->\n```\n$ run\n\x1b[31mred\x1b[0m line\n```\n"
+    html = markdown(
+        md,
+        extensions=["fenced_code", TermynalExtension(ansi=True)],
+    )
+    assert '<span style="color: #aa0000">red</span> line' in html
+    # The command line stays a normal termynal input.
+    assert '<span data-ty="input" data-ty-prompt="$">run</span>' in html
+
+
+def test_ansi_disabled_keeps_escape_codes_literal():
+    md = "<!-- termynal -->\n```\n\x1b[31mred\x1b[0m line\n```\n"
+    html = markdown(
+        md,
+        extensions=["fenced_code", TermynalExtension()],
+    )
+    assert "color: #aa0000" not in html
+
+
+def test_ansi_per_block_override():
+    md = (
+        "<!-- termynal: ansi: true -->\n"
+        "```\n$ run\n\x1b[32mgreen\x1b[0m\n```\n"
+    )
+    html = markdown(
+        md,
+        extensions=["fenced_code", TermynalExtension()],
+    )
+    assert "color: #00aa00" in html

--- a/tests/test_markdown_extension.py
+++ b/tests/test_markdown_extension.py
@@ -126,6 +126,24 @@ def test_ansi_disabled_keeps_escape_codes_literal():
     assert "color: #aa0000" not in html
 
 
+@pytest.mark.parametrize(
+    "line",
+    [
+        "\x1b[31mno reset",
+        "\x1b[ broken \x1b[0m",
+        "\x1b[2J\x1b[1;1Hcursor codes",
+        "carriage\rreturn",
+        "\x1b[7mreverse\x1b[0m",
+        "abc\x08\x08\x1b[32mxy\x1b[0m",
+    ],
+    ids=["no-reset", "broken", "cursor-codes", "carriage-return", "reverse", "backspace"],
+)
+def test_ansi_handles_malformed_input_without_raising(line: str):
+    md = "<!-- termynal: ansi: true -->\n```\n" + line + "\n```\n"
+    html = markdown(md, extensions=["fenced_code", TermynalExtension(ansi=True)])
+    assert html.count("<span") == html.count("</span>")
+
+
 def test_ansi_does_not_alter_ansi_free_output():
     md = "<!-- termynal -->\n```\n$ echo hi\nplain \"quoted\" & <stuff>\n```\n"
     off = markdown(md, extensions=["fenced_code", TermynalExtension(ansi=False)])

--- a/tests/test_markdown_extension.py
+++ b/tests/test_markdown_extension.py
@@ -113,8 +113,7 @@ def test_ansi_output_is_converted_to_spans():
         md,
         extensions=["fenced_code", TermynalExtension(ansi=True)],
     )
-    assert '<span style="color: #aa0000">red</span> line' in html
-    # The command line stays a normal termynal input.
+    assert '<span style="color: #cd0000">red</span> line' in html
     assert '<span data-ty="input" data-ty-prompt="$">run</span>' in html
 
 
@@ -127,6 +126,33 @@ def test_ansi_disabled_keeps_escape_codes_literal():
     assert "color: #aa0000" not in html
 
 
+def test_ansi_default_scheme_is_xterm():
+    md = "<!-- termynal -->\n```\n\x1b[31mred\x1b[0m\n```\n"
+    html = markdown(md, extensions=["fenced_code", TermynalExtension(ansi=True)])
+    assert "color: #cd0000" in html
+
+
+def test_ansi_scheme_override():
+    md = "<!-- termynal -->\n```\n\x1b[31mred\x1b[0m\n```\n"
+    html = markdown(
+        md,
+        extensions=["fenced_code", TermynalExtension(ansi=True, ansi_scheme="osx")],
+    )
+    assert "color: #c23621" in html
+
+
+def test_ansi_invalid_scheme_falls_back_to_default():
+    md = "<!-- termynal -->\n```\n\x1b[31mred\x1b[0m\n```\n"
+    html = markdown(
+        md,
+        extensions=[
+            "fenced_code",
+            TermynalExtension(ansi=True, ansi_scheme="not-a-scheme"),
+        ],
+    )
+    assert "color: #cd0000" in html
+
+
 def test_ansi_per_block_override():
     md = (
         "<!-- termynal: ansi: true -->\n"
@@ -136,4 +162,4 @@ def test_ansi_per_block_override():
         md,
         extensions=["fenced_code", TermynalExtension()],
     )
-    assert "color: #00aa00" in html
+    assert "color: #00cd00" in html

--- a/tests/test_markdown_extension.py
+++ b/tests/test_markdown_extension.py
@@ -126,6 +126,13 @@ def test_ansi_disabled_keeps_escape_codes_literal():
     assert "color: #aa0000" not in html
 
 
+def test_ansi_does_not_alter_ansi_free_output():
+    md = "<!-- termynal -->\n```\n$ echo hi\nplain \"quoted\" & <stuff>\n```\n"
+    off = markdown(md, extensions=["fenced_code", TermynalExtension(ansi=False)])
+    on = markdown(md, extensions=["fenced_code", TermynalExtension(ansi=True)])
+    assert off == on
+
+
 def test_ansi_default_scheme_is_xterm():
     md = "<!-- termynal -->\n```\n\x1b[31mred\x1b[0m\n```\n"
     html = markdown(md, extensions=["fenced_code", TermynalExtension(ansi=True)])

--- a/uv.lock
+++ b/uv.lock
@@ -934,6 +934,7 @@ dev = [
     { name = "types-pyyaml" },
 ]
 docs = [
+    { name = "ansi2html" },
     { name = "markdown-include" },
     { name = "mkdocs" },
     { name = "mkdocs-material" },
@@ -966,6 +967,7 @@ dev = [
     { name = "types-pyyaml", specifier = ">=6.0" },
 ]
 docs = [
+    { name = "ansi2html", specifier = ">=1.8" },
     { name = "markdown-include", specifier = ">=0.8" },
     { name = "mkdocs", specifier = ">=1.6" },
     { name = "mkdocs-material", specifier = ">=9.5" },

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "ansi2html"
+version = "1.9.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/d5/e3546dcd5e4a9566f4ed8708df5853e83ca627461a5b048a861c6f8e7a26/ansi2html-1.9.2.tar.gz", hash = "sha256:3453bf87535d37b827b05245faaa756dbab4ec3d69925e352b6319c3c955c0a5", size = 44300, upload-time = "2024-06-22T17:33:23.964Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/71/aee71b836e9ee2741d5694b80d74bfc7c8cd5dbdf7a9f3035fcf80d792b1/ansi2html-1.9.2-py3-none-any.whl", hash = "sha256:dccb75aa95fb018e5d299be2b45f802952377abfdce0504c17a6ee6ef0a420c5", size = 17614, upload-time = "2024-06-22T17:33:21.852Z" },
+]
+
+[[package]]
 name = "argcomplete"
 version = "3.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -897,19 +906,23 @@ wheels = [
 
 [[package]]
 name = "termynal"
-version = "0.13.1"
+version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "markdown" },
 ]
 
 [package.optional-dependencies]
+ansi = [
+    { name = "ansi2html" },
+]
 mkdocs = [
     { name = "mkdocs" },
 ]
 
 [package.dev-dependencies]
 dev = [
+    { name = "ansi2html" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -933,13 +946,15 @@ git = [
 
 [package.metadata]
 requires-dist = [
+    { name = "ansi2html", marker = "extra == 'ansi'", specifier = ">=1.8" },
     { name = "markdown", specifier = ">=3" },
     { name = "mkdocs", marker = "extra == 'mkdocs'", specifier = ">=1.4" },
 ]
-provides-extras = ["mkdocs"]
+provides-extras = ["mkdocs", "ansi"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "ansi2html", specifier = ">=1.8" },
     { name = "mypy", specifier = ">=1.13.0" },
     { name = "pytest", specifier = ">=7.4" },
     { name = "pytest-cov", specifier = ">=4.1" },


### PR DESCRIPTION
Hi, Im using termynal in my docs and document my cli tools (typer) with it. But im missing the colored outputs they generate. I think this greatly improves the visual appeal of using termynal auto-documentation of cli tools

```bash
uv --help
```

> [!NOTE]
> This description was drafted by AI (Claude)

## What

Adds an opt-in `ansi` option that renders ANSI color sequences (from tools like [rich](https://github.com/Textualize/rich), [typer](https://github.com/fastapi/typer), `uv`, `git`, …) as colored HTML, instead of escaping them to literal text.

Refs #14.

```yaml
plugins:
  - termynal:
      ansi: true
```

…or per block: `<!-- termynal: ansi: true -->`

## How

- Conversion is done by [`ansi2html`](https://pypi.org/project/ansi2html/), imported lazily and shipped as an **optional extra** (`pip install 'termynal[ansi]'`) so the core install gains no new dependency.
- Output lines are converted **per line**, so color spans stay balanced within each rendered terminal line. 256-color and 24-bit truecolor pass through faithfully.
- Colors render on **output** lines (the rich/typer case); typed command lines stay plain, since `termynal.js` animates them via `textContent`.

## Options

| name | default | |
|------|---------|--|
| `ansi` | `false` | render ANSI colors as HTML |
| `ansi_scheme` | `"xterm"` | palette for the 16 base colors: `ansi2html`, `dracula`, `mint-terminal`, `osx`, `osx-basic`, `osx-solid-colors`, `solarized`, `xterm` |
| `ansi_dark_bg` | `true` | dark-background palette variant |

`xterm` is the default (truer to a real terminal than ansi2html's own palette, whose "yellow" renders brown). Invalid schemes fall back to the default.

## Backwards compatibility

`ansi` defaults to `false`, so existing output is byte-for-byte unchanged — the golden snapshot tests in `tests/test_cases.yml` still pass. The new dependency is only imported when `ansi: true`.

## Docs

`docs/configuration.md` documents the options and shows a live colored `uv -h` example. The ANSI bytes are committed directly so the example renders under **both** the mkdocs and zensical builds (verified `zensical build` and `mkdocs build --strict`).

## Tests

Adds coverage for conversion on/off, scheme override, invalid-scheme fallback, and per-block override. Full suite (30 tests), `ruff`, and `mypy` all pass.