### PR TITLE
feat: termynal.exec helper to generate blocks from commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,43 @@ extra_javascript = ["javascripts/termynal.js"]
 include_assets = false
 ```
 
+### Colored output (rich, typer, …)
+
+Tools like [rich](https://github.com/Textualize/rich) and
+[typer](https://github.com/fastapi/typer) emit ANSI color sequences. Enable the
+`ansi` option to convert those sequences into colored HTML instead of escaping
+them. It requires the optional `ansi2html` dependency:
+
+```
+pip install 'termynal[ansi]'
+```
+
+Then turn it on globally:
+
+```yaml
+[...]
+plugins:
+  - termynal:
+      ansi: true
+[...]
+```
+
+or per block:
+
+````markdown
+<!-- termynal: ansi: true -->
+
+```
+$ python app.py
+```
+````
+
+Paste the raw ANSI output into the code block (e.g. capture it with
+`rich.console.Console(force_terminal=True)`, `FORCE_COLOR=1`, or typer's
+`--color`). Each output line is converted independently with inline styles, so
+no extra CSS is needed. Colors render on output lines; typed command lines are
+shown as plain text by the animation.
+
 ## Credits
 
 Thanks [ines](https://github.com/ines/termynal)

--- a/README.md
+++ b/README.md
@@ -114,59 +114,22 @@ include_assets = false
 ### Colored output (rich, typer, …)
 
 Tools like [rich](https://github.com/Textualize/rich) and
-[typer](https://github.com/fastapi/typer) emit ANSI color sequences. Enable the
-`ansi` option to convert those sequences into colored HTML instead of escaping
-them. It requires the optional `ansi2html` dependency:
-
-```
-pip install 'termynal[ansi]'
-```
-
-Then turn it on globally:
-
-```yaml
-[...]
-plugins:
-  - termynal:
-      ansi: true
-[...]
-```
-
-or per block:
+[typer](https://github.com/fastapi/typer) emit ANSI color sequences. Set
+`ansi: true` to render them as colored HTML instead of escaping them (requires
+the optional dependency: `pip install 'termynal[ansi]'`):
 
 ````markdown
 <!-- termynal: ansi: true -->
 
 ```
-$ python app.py
+$ uv -h
 ```
 ````
 
-Paste the raw ANSI output into the code block (e.g. capture it with
-`rich.console.Console(force_terminal=True)`, `FORCE_COLOR=1`, or typer's
-`--color`). Each output line is converted independently with inline styles, so
-no extra CSS is needed. Colors render on output lines; typed command lines are
-shown as plain text by the animation.
-
-The 16 base ANSI colors are mapped through a palette. The default is `xterm`
-(the canonical reference terminal palette); other options are `ansi2html`,
-`osx`, `osx-basic`, `osx-solid-colors`, `dracula`, `solarized`, and
-`mint-terminal`. 256-color and 24-bit truecolor sequences are always mapped
-faithfully, regardless of the scheme.
-
-```yaml
-[...]
-plugins:
-  - termynal:
-      ansi: true
-      ansi_scheme: xterm
-      ansi_dark_bg: true
-[...]
-```
-
-> Tip: for pixel-exact colors, tell the tool to emit 24-bit color (e.g.
-> `rich.console.Console(color_system="truecolor")`) — the base-color palette is
-> then bypassed entirely.
+Paste the raw colored output into the block (capture it with `FORCE_COLOR=1` or
+rich's `force_terminal=True`). Colors render on output lines; typed commands
+stay plain. The palette (`ansi_scheme`) and other options are documented in
+[Configuration](https://termynal.github.io/termynal.py/configuration/).
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ include_assets = true
 title = "bash"
 buttons = "macos"
 prompt_literal_start = ["$"]
+ansi = false
 ```
 
 You can override default assets with your own files:

--- a/README.md
+++ b/README.md
@@ -147,6 +147,26 @@ Paste the raw ANSI output into the code block (e.g. capture it with
 no extra CSS is needed. Colors render on output lines; typed command lines are
 shown as plain text by the animation.
 
+The 16 base ANSI colors are mapped through a palette. The default is `xterm`
+(the canonical reference terminal palette); other options are `ansi2html`,
+`osx`, `osx-basic`, `osx-solid-colors`, `dracula`, `solarized`, and
+`mint-terminal`. 256-color and 24-bit truecolor sequences are always mapped
+faithfully, regardless of the scheme.
+
+```yaml
+[...]
+plugins:
+  - termynal:
+      ansi: true
+      ansi_scheme: xterm
+      ansi_dark_bg: true
+[...]
+```
+
+> Tip: for pixel-exact colors, tell the tool to emit 24-bit color (e.g.
+> `rich.console.Console(color_system="truecolor")`) — the base-color palette is
+> then bypassed entirely.
+
 ## Credits
 
 Thanks [ines](https://github.com/ines/termynal)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,5 +1,7 @@
 # Configuration
 
+## Options
+
 | **name**             | **default** |                        |
 |----------------------|-------------|------------------------|
 | title                | `"bash"`    |                        |
@@ -11,6 +13,10 @@
 | ansi                 | `false`     | render ANSI colors as HTML |
 | ansi_scheme          | `"xterm"`   | `ansi2html`, `dracula`, `mint-terminal`, `osx`, `osx-basic`, `osx-solid-colors`, `solarized`, `xterm` |
 | ansi_dark_bg         | `true`      | dark-background palette variant |
+
+## Global configuration
+
+Set defaults for every block in `mkdocs.yml`:
 
 ```yaml
 plugins:
@@ -27,7 +33,11 @@ plugins:
       ansi_dark_bg: true
 ```
 
+## Per-block overrides
+
 You can override configurations for each block. If you set a part of the settings, the other part will be set to the default value from `mkdocs.yml`.
+
+### Custom prompt and buttons
 
 `<!-- termynal: {"prompt_literal_start": ["$", ">>>", "PS >"], title: powershell, buttons: windows} -->`
 
@@ -45,7 +55,7 @@ PS > python
 >>> import json
 ```
 
-## Colored output
+### Colored output
 
 With `ansi: true` (requires `pip install 'termynal[ansi]'`), ANSI color
 sequences from tools like [rich](https://github.com/Textualize/rich) and

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -79,3 +79,36 @@ An extremely fast Python package manager.
   [1m[36mlock[0m     Update the project's lockfile
 ```
 
+#### Generating blocks from a command
+
+Pasting `--help` output by hand goes stale. The `termynal.exec` helper runs a
+command for you and prints a ready-to-paste, colored termynal block. It is a
+standalone authoring step — termynal itself never executes anything, so pages
+stay a pure text-to-HTML transform.
+
+```
+$ python -m termynal.exec "mytool --help" --title mytool
+<!-- termynal: {ansi: true, title: mytool} -->
+```
+
+It runs the command with `FORCE_COLOR=1` and a fixed `COLUMNS` width (so wrapping
+is reproducible), captures stdout and stderr, and emits the block. Colors come
+through for tools that honor `FORCE_COLOR` such as rich, typer, and click; add
+`--pty` for CLIs that check `isatty` directly (POSIX only).
+
+The helper adds **no dependencies** of its own (standard library only), and the
+command it runs is your own tool, already installed in your docs environment.
+Rendering the captured ANSI still needs `pip install 'termynal[ansi]'`.
+
+Pipe it into a page, or wire it into a [cog](https://nedbatchelder.com/code/cog/)
+block or pre-commit hook to keep the output fresh. Useful flags:
+
+| Flag | Purpose |
+| --- | --- |
+| `--title` | Terminal title for the block. |
+| `--prompt` | Prompt shown before the command (default `$`). |
+| `--columns` | Width passed to the command (default `80`). |
+| `--timeout` | Seconds before the command is killed (default `30`). |
+| `--cwd` | Working directory for the command. |
+| `--no-color` / `--no-ansi` | Capture without color / omit `ansi: true`. |
+| `--pty` | Run under a pseudo-terminal for stubborn CLIs. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,10 +91,18 @@ $ python -m termynal.exec "mytool --help" --title mytool
 <!-- termynal: {ansi: true, title: mytool} -->
 ```
 
-It runs the command with `FORCE_COLOR=1` and a fixed `COLUMNS` width (so wrapping
-is reproducible), captures stdout and stderr, and emits the block. Colors come
-through for tools that honor `FORCE_COLOR` such as rich, typer, and click; add
-`--pty` for CLIs that check `isatty` directly (POSIX only).
+It runs the command with a fixed `COLUMNS` width (so wrapping is reproducible),
+captures the output, and emits the block. To make color survive being captured,
+on POSIX it runs the command under a pseudo-terminal by default, so even tools
+that check `isatty` directly (such as `uv`) come through colored — no flag
+needed:
+
+```
+$ python -m termynal.exec "uv -h"
+```
+
+On Windows it falls back to `FORCE_COLOR=1` (honored by rich, typer, click).
+Use `--no-pty` if you need stdout and stderr kept apart instead of interleaved.
 
 The helper adds **no dependencies** of its own (standard library only), and the
 command it runs is your own tool, already installed in your docs environment.
@@ -111,4 +119,4 @@ block or pre-commit hook to keep the output fresh. Useful flags:
 | `--timeout` | Seconds before the command is killed (default `30`). |
 | `--cwd` | Working directory for the command. |
 | `--no-color` / `--no-ansi` | Capture without color / omit `ansi: true`. |
-| `--pty` | Run under a pseudo-terminal for stubborn CLIs. |
+| `--pty` / `--no-pty` | Force / disable the pseudo-terminal (auto: on with color on POSIX). |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,3 +120,20 @@ block or pre-commit hook to keep the output fresh. Useful flags:
 | `--cwd` | Working directory for the command. |
 | `--no-color` / `--no-ansi` | Capture without color / omit `ansi: true`. |
 | `--pty` / `--no-pty` | Force / disable the pseudo-terminal (auto: on with color on POSIX). |
+
+!!! tip "Recommended workflow: generate, then commit"
+    termynal never runs anything at render time, and `termynal.exec` is a
+    separate authoring step — so generate the block once and commit it, keeping
+    your page source short:
+
+    ```
+    python -m termynal.exec "uv -h" >> docs/cli.md
+    ```
+
+    Re-run it when the tool changes. To keep many `--help` blocks fresh
+    automatically, drive the helper from a
+    [cog](https://nedbatchelder.com/code/cog/) block or a pre-commit hook and add
+    `cog --check` in CI. Avoid wiring the execution into the site build itself:
+    committing the generated block keeps the rendered output identical across
+    `mkdocs serve` and the published site, and keeps the build a pure, safe
+    text-to-HTML step.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,6 +8,9 @@
 | include_assets       | `false`     |                        |
 | assets_override_css  | `null`      | path to custom css file |
 | assets_override_js   | `null`      | path to custom js file  |
+| ansi                 | `false`     | render ANSI colors as HTML |
+| ansi_scheme          | `"xterm"`   | `ansi2html`, `dracula`, `mint-terminal`, `osx`, `osx-basic`, `osx-solid-colors`, `solarized`, `xterm` |
+| ansi_dark_bg         | `true`      | dark-background palette variant |
 
 ```yaml
 plugins:
@@ -19,6 +22,9 @@ plugins:
       include_assets: false
       assets_override_css: null
       assets_override_js: null
+      ansi: false
+      ansi_scheme: xterm
+      ansi_dark_bg: true
 ```
 
 You can override configurations for each block. If you set a part of the settings, the other part will be set to the default value from `mkdocs.yml`.
@@ -38,3 +44,28 @@ PS > python
 PS > python
 >>> import json
 ```
+
+## Colored output
+
+With `ansi: true` (requires `pip install 'termynal[ansi]'`), ANSI color
+sequences from tools like [rich](https://github.com/Textualize/rich) and
+[typer](https://github.com/fastapi/typer) are rendered as colored HTML instead
+of being escaped. Paste the raw colored output into the block:
+
+<!-- termynal: ansi: true -->
+
+```
+$ uv -h
+An extremely fast Python package manager.
+
+[1m[32mUsage:[0m [1m[36muv[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
+
+[1m[32mCommands:[0m
+  [1m[36mrun[0m      Run a command or script
+  [1m[36minit[0m     Create a new project
+  [1m[36madd[0m      Add dependencies to the project
+  [1m[36mremove[0m   Remove dependencies from the project
+  [1m[36msync[0m     Update the project's environment
+  [1m[36mlock[0m     Update the project's lockfile
+```
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dev = [
     "types-pyyaml >= 6.0",
 ]
 docs = [
+    "ansi2html >= 1.8",
     "markdown-include >= 0.8",
     "mkdocs >= 1.6",
     "mkdocs-material >= 9.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,11 @@ Documentation = "https://termynal.github.io/termynal.py/"
 
 [project.optional-dependencies]
 mkdocs = ["mkdocs >= 1.4"]
+ansi = ["ansi2html >= 1.8"]
 
 [dependency-groups]
 dev = [
+    "ansi2html >= 1.8",
     "mypy >= 1.13.0",
     "pytest >= 7.4",
     "pytest-cov >= 4.1",

--- a/termynal/exec.py
+++ b/termynal/exec.py
@@ -1,0 +1,258 @@
+"""Run a command and emit a termynal-ready Markdown block.
+
+This is a *standalone* authoring helper. It executes a command and prints a
+fenced ``<!-- termynal -->`` block that captures the command's (optionally
+colored) output. termynal's rendering core stays a pure text->HTML transform:
+execution lives here, in an explicit step you run yourself (locally, in a
+pre-commit hook, or in CI), never inside ``mkdocs build``.
+
+The block it prints is *termynal-ready Markdown*, not HTML. termynal remains the
+single renderer that turns ANSI sequences into colored spans and the prompt line
+into an animated input, so there is exactly one ANSI converter and one set of
+color schemes to maintain.
+
+Example::
+
+    python -m termynal.exec mytool --help
+
+Pipe the output into a docs page, or paste it in. Colors come through because we
+run the command with ``FORCE_COLOR=1`` (respected by rich/click/typer and many
+others); use ``--pty`` for CLIs that strictly check ``isatty``.
+"""
+
+import argparse
+import os
+import shlex
+import subprocess
+import sys
+from typing import Dict, List, Optional, Sequence
+
+
+def run_command(
+    command: Sequence[str],
+    *,
+    columns: int = 80,
+    timeout: Optional[float] = 30.0,
+    cwd: Optional[str] = None,
+    env: Optional[Dict[str, str]] = None,
+    color: bool = True,
+    merge_stderr: bool = True,
+    use_pty: bool = False,
+) -> str:
+    """Run ``command`` and return its captured output as text.
+
+    ``columns`` pins terminal width so output wrapping is reproducible.
+    ``color`` sets ``FORCE_COLOR``/``NO_COLOR`` so ANSI is kept (or dropped)
+    even though stdout is captured rather than a TTY. ``use_pty`` runs the
+    command under a pseudo-terminal (POSIX only) for CLIs that ignore
+    ``FORCE_COLOR`` and check ``isatty`` directly.
+    """
+    run_env = dict(os.environ if env is None else env)
+    run_env["COLUMNS"] = str(columns)
+    if color:
+        run_env["FORCE_COLOR"] = "1"
+        run_env.pop("NO_COLOR", None)
+    else:
+        run_env["NO_COLOR"] = "1"
+        run_env.pop("FORCE_COLOR", None)
+
+    if use_pty:
+        return _run_with_pty(command, run_env, cwd, timeout, columns)
+
+    proc = subprocess.run(  # noqa: S603
+        list(command),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        cwd=cwd,
+        env=run_env,
+        check=False,
+    )
+    out = proc.stdout or ""
+    if merge_stderr and proc.stderr:
+        out = f"{out}{proc.stderr}" if out else proc.stderr
+    return out
+
+
+def _run_with_pty(
+    command: Sequence[str],
+    env: Dict[str, str],
+    cwd: Optional[str],
+    timeout: Optional[float],
+    columns: int,
+) -> str:
+    """Run ``command`` under a pseudo-terminal and return combined output.
+
+    POSIX only. stdout and stderr are interleaved on the same stream, exactly
+    as a real terminal would see them.
+    """
+    import fcntl
+    import pty
+    import select
+    import struct
+    import termios
+    import time
+
+    master, slave = pty.openpty()
+    fcntl.ioctl(master, termios.TIOCSWINSZ, struct.pack("HHHH", 24, columns, 0, 0))
+    proc = subprocess.Popen(  # noqa: S603
+        list(command),
+        stdin=slave,
+        stdout=slave,
+        stderr=slave,
+        cwd=cwd,
+        env=env,
+        close_fds=True,
+    )
+    os.close(slave)
+
+    chunks: List[bytes] = []
+    deadline = None if timeout is None else time.monotonic() + timeout
+    try:
+        while True:
+            wait = None if deadline is None else max(0.0, deadline - time.monotonic())
+            if deadline is not None and wait == 0.0:
+                proc.kill()
+                raise subprocess.TimeoutExpired(list(command), timeout)
+            ready, _, _ = select.select([master], [], [], wait)
+            if not ready:
+                continue
+            try:
+                data = os.read(master, 4096)
+            except OSError:
+                break
+            if not data:
+                break
+            chunks.append(data)
+    finally:
+        os.close(master)
+        proc.wait()
+    return b"".join(chunks).decode("utf-8", errors="replace")
+
+
+def to_termynal_block(
+    command_display: str,
+    output: str,
+    *,
+    ansi: bool = True,
+    prompt: str = "$",
+    title: Optional[str] = None,
+    fence: str = "```",
+) -> str:
+    """Build a termynal Markdown block from a command and its captured output.
+
+    The command becomes the animated input line; ``output`` follows verbatim,
+    ANSI escapes and all, for termynal to render when ``ansi`` is enabled.
+    """
+    options: Dict[str, object] = {}
+    if ansi:
+        options["ansi"] = True
+    if title is not None:
+        options["title"] = title
+
+    if not options:
+        header = "<!-- termynal -->"
+    elif list(options) == ["ansi"]:
+        # Single key: match the plain form used throughout the docs.
+        header = "<!-- termynal: ansi: true -->"
+    else:
+        inner = ", ".join(_format_option(k, v) for k, v in options.items())
+        header = f"<!-- termynal: {{{inner}}} -->"
+
+    lines = [f"{prompt} {command_display}"]
+    body = output.replace("\r\n", "\n").rstrip("\n")
+    if body:
+        lines.extend(body.split("\n"))
+    return f"{header}\n{fence}\n" + "\n".join(lines) + f"\n{fence}\n"
+
+
+def _format_option(key: str, value: object) -> str:
+    if isinstance(value, bool):
+        return f"{key}: {'true' if value else 'false'}"
+    return f"{key}: {value}"
+
+
+def render(
+    command: Sequence[str],
+    *,
+    command_display: Optional[str] = None,
+    ansi: bool = True,
+    prompt: str = "$",
+    title: Optional[str] = None,
+    **run_kwargs: object,
+) -> str:
+    """Run ``command`` and return a termynal-ready Markdown block."""
+    output = run_command(command, **run_kwargs)  # type: ignore[arg-type]
+    display = command_display if command_display is not None else shlex.join(command)
+    return to_termynal_block(
+        display,
+        output,
+        ansi=ansi,
+        prompt=prompt,
+        title=title,
+    )
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m termynal.exec",
+        description="Run a command and print a termynal-ready Markdown block.",
+    )
+    parser.add_argument(
+        "command",
+        nargs="+",
+        help="Command to run, e.g. mytool --help (quote it or use -- to pass flags).",
+    )
+    parser.add_argument("--prompt", default="$", help="Prompt shown before the command.")
+    parser.add_argument("--title", default=None, help="Terminal title for the block.")
+    parser.add_argument(
+        "--columns",
+        type=int,
+        default=80,
+        help="Terminal width passed to the command (default: 80).",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=30.0,
+        help="Seconds before the command is killed (default: 30).",
+    )
+    parser.add_argument("--cwd", default=None, help="Working directory for the command.")
+    parser.add_argument(
+        "--no-color",
+        action="store_true",
+        help="Do not force ANSI color; emit a plain block.",
+    )
+    parser.add_argument(
+        "--no-ansi",
+        action="store_true",
+        help="Omit 'ansi: true' from the block even when color is captured.",
+    )
+    parser.add_argument(
+        "--pty",
+        action="store_true",
+        help="Run under a pseudo-terminal (POSIX) for CLIs that check isatty.",
+    )
+    args = parser.parse_args(argv)
+
+    # A single quoted argument like "mytool --help" is split into argv.
+    command = shlex.split(args.command[0]) if len(args.command) == 1 else args.command
+
+    block = render(
+        command,
+        command_display=shlex.join(command),
+        ansi=not args.no_ansi,
+        prompt=args.prompt,
+        title=args.title,
+        columns=args.columns,
+        timeout=args.timeout,
+        cwd=args.cwd,
+        color=not args.no_color,
+        use_pty=args.pty,
+    )
+    sys.stdout.write(block)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/termynal/exec.py
+++ b/termynal/exec.py
@@ -37,16 +37,25 @@ def run_command(
     env: Optional[Dict[str, str]] = None,
     color: bool = True,
     merge_stderr: bool = True,
-    use_pty: bool = False,
+    use_pty: Optional[bool] = None,
 ) -> str:
     """Run ``command`` and return its captured output as text.
 
     ``columns`` pins terminal width so output wrapping is reproducible.
     ``color`` sets ``FORCE_COLOR``/``NO_COLOR`` so ANSI is kept (or dropped)
-    even though stdout is captured rather than a TTY. ``use_pty`` runs the
-    command under a pseudo-terminal (POSIX only) for CLIs that ignore
-    ``FORCE_COLOR`` and check ``isatty`` directly.
+    even though stdout is captured rather than a TTY.
+
+    ``use_pty`` runs the command under a pseudo-terminal so even CLIs that
+    ignore ``FORCE_COLOR`` and check ``isatty`` directly (e.g. ``uv``) emit
+    color. It defaults to ``None`` = auto: enabled when ``color`` is requested
+    and the platform is POSIX, off otherwise. Pass ``True``/``False`` to force
+    it. A pty interleaves stdout and stderr, so ``merge_stderr`` only applies to
+    the non-pty path; force ``use_pty=False`` when you need the streams kept
+    apart.
     """
+    if use_pty is None:
+        use_pty = color and os.name == "posix"
+
     run_env = dict(os.environ if env is None else env)
     run_env["COLUMNS"] = str(columns)
     if color:
@@ -231,9 +240,20 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     parser.add_argument(
         "--pty",
         action="store_true",
-        help="Run under a pseudo-terminal (POSIX) for CLIs that check isatty.",
+        help="Force a pseudo-terminal (POSIX). On by default when color is on.",
+    )
+    parser.add_argument(
+        "--no-pty",
+        action="store_true",
+        help="Force the plain pipe path even when capturing color.",
     )
     args = parser.parse_args(argv)
+
+    use_pty: Optional[bool] = None
+    if args.no_pty:
+        use_pty = False
+    elif args.pty:
+        use_pty = True
 
     # A single quoted argument like "mytool --help" is split into argv.
     command = shlex.split(args.command[0]) if len(args.command) == 1 else args.command
@@ -248,7 +268,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         timeout=args.timeout,
         cwd=args.cwd,
         color=not args.no_color,
-        use_pty=args.pty,
+        use_pty=use_pty,
     )
     sys.stdout.write(block)
     return 0

--- a/termynal/markdown.py
+++ b/termynal/markdown.py
@@ -39,6 +39,7 @@ class Config(NamedTuple):
     include_assets: bool
     assets_override_css: Optional[str]
     assets_override_js: Optional[str]
+    ansi: bool
 
 
 class Command(NamedTuple):
@@ -81,6 +82,28 @@ def escape(txt: str) -> str:
     txt = txt.replace(">", "&gt;")
     txt = txt.replace('"', "&quot;")
     return txt  # noqa:RET504
+
+
+def ansi_escape(code: str) -> str:
+    """Escape ``code`` while turning ANSI color sequences into HTML spans.
+
+    Each line is converted independently so color spans are always balanced
+    within a line (termynal renders every output line as its own element).
+    Literal text is HTML-escaped by ``ansi2html`` itself, so the result is a
+    drop-in replacement for :func:`escape` when ANSI support is enabled.
+    """
+    try:
+        from ansi2html import Ansi2HTMLConverter
+    except ImportError as exc:  # pragma:no cover
+        raise ImportError(
+            "ANSI support requires the 'ansi2html' package. "
+            "Install it with: pip install 'termynal[ansi]'",
+        ) from exc
+
+    converter = Ansi2HTMLConverter(inline=True)
+    return "\n".join(
+        converter.convert(line, full=False) for line in code.split("\n")
+    )
 
 
 def remove_spaces(code: str, spaces: str) -> str:
@@ -140,6 +163,11 @@ def parse_config_from_dict(
     if assets_override_js is not None:
         assets_override_js = str(assets_override_js).strip() or None
 
+    ansi_default = default.ansi if default else False
+    ansi = config.get("ansi", ansi_default)
+    if not isinstance(ansi, bool):
+        ansi = ansi_default
+
     return Config(
         title=str(config.get("title", default.title if default else "bash")),
         prompt_literal_start=list(
@@ -152,6 +180,7 @@ def parse_config_from_dict(
         include_assets=include_assets,
         assets_override_css=assets_override_css,
         assets_override_js=assets_override_js,
+        ansi=ansi,
     )
 
 
@@ -320,8 +349,9 @@ class TermynalPreprocessor(Preprocessor):
                     if config:
                         termynal = Termynal(config)
 
+                escaper = ansi_escape if termynal.config.ansi else escape
                 converted_code = add_spaces(
-                    termynal.convert(escape(remove_spaces(code, spaces))),
+                    termynal.convert(escaper(remove_spaces(code, spaces))),
                     spaces,
                 )
                 text = f"{text[:start]}\n{converted_code}\n{text[end:]}"
@@ -367,6 +397,12 @@ class TermynalExtension(Extension):
                 "",
                 "Path to a custom JS file to inline instead of the built-in "
                 "termynal.js when include_assets is true.",
+            ],
+            "ansi": [
+                False,
+                "Convert ANSI color sequences (e.g. from rich/typer output) into "
+                "HTML spans instead of escaping them. Requires the 'ansi2html' "
+                "package. Default: False",
             ],
         }
 

--- a/termynal/markdown.py
+++ b/termynal/markdown.py
@@ -106,20 +106,27 @@ def ansi_escape(
 ) -> str:
     """Escape ``code``, turning ANSI color sequences into HTML spans.
 
-    Converted per line so spans stay balanced within each terminal line.
+    Lines without an escape sequence are passed through :func:`escape`
+    unchanged, so enabling ``ansi`` does not alter ANSI-free output. Lines that
+    do contain ANSI are converted individually, keeping spans balanced per line.
     """
-    try:
-        from ansi2html import Ansi2HTMLConverter
-    except ImportError as exc:  # pragma:no cover
-        raise ImportError(
-            "ANSI support requires the 'ansi2html' package. "
-            "Install it with: pip install 'termynal[ansi]'",
-        ) from exc
-
-    converter = Ansi2HTMLConverter(inline=True, scheme=scheme, dark_bg=dark_bg)
-    return "\n".join(
-        converter.convert(line, full=False) for line in code.split("\n")
-    )
+    converter = None
+    result = []
+    for line in code.split("\n"):
+        if "\x1b" not in line:
+            result.append(escape(line))
+            continue
+        if converter is None:
+            try:
+                from ansi2html import Ansi2HTMLConverter
+            except ImportError as exc:  # pragma:no cover
+                raise ImportError(
+                    "ANSI support requires the 'ansi2html' package. "
+                    "Install it with: pip install 'termynal[ansi]'",
+                ) from exc
+            converter = Ansi2HTMLConverter(inline=True, scheme=scheme, dark_bg=dark_bg)
+        result.append(converter.convert(line, full=False))
+    return "\n".join(result)
 
 
 def remove_spaces(code: str, spaces: str) -> str:
@@ -257,6 +264,12 @@ class Termynal:
         self.progress_literal_start = progress_literal_start
         self.comment_literal_start = comment_literal_start
 
+    def escape(self, code: str) -> str:
+        """Escape code, converting ANSI to spans when ``ansi`` is enabled."""
+        if self.config.ansi:
+            return ansi_escape(code, self.config.ansi_scheme, self.config.ansi_dark_bg)
+        return escape(code)
+
     def convert(self, code: str) -> str:
         """Converts bash code to termynal HTML.
 
@@ -377,16 +390,7 @@ class TermynalPreprocessor(Preprocessor):
                     if config:
                         termynal = Termynal(config)
 
-                cleaned = remove_spaces(code, spaces)
-                escaped = (
-                    ansi_escape(
-                        cleaned,
-                        termynal.config.ansi_scheme,
-                        termynal.config.ansi_dark_bg,
-                    )
-                    if termynal.config.ansi
-                    else escape(cleaned)
-                )
+                escaped = termynal.escape(remove_spaces(code, spaces))
                 converted_code = add_spaces(termynal.convert(escaped), spaces)
                 text = f"{text[:start]}\n{converted_code}\n{text[end:]}"
                 termynal = default_termynal

--- a/termynal/markdown.py
+++ b/termynal/markdown.py
@@ -32,6 +32,19 @@ class Buttons(str, Enum):
     WINDOWS = "windows"
 
 
+ANSI_SCHEMES = (
+    "ansi2html",
+    "dracula",
+    "mint-terminal",
+    "osx",
+    "osx-basic",
+    "osx-solid-colors",
+    "solarized",
+    "xterm",
+)
+DEFAULT_ANSI_SCHEME = "xterm"
+
+
 class Config(NamedTuple):
     title: str
     prompt_literal_start: Sequence[str]
@@ -40,6 +53,8 @@ class Config(NamedTuple):
     assets_override_css: Optional[str]
     assets_override_js: Optional[str]
     ansi: bool
+    ansi_scheme: str
+    ansi_dark_bg: bool
 
 
 class Command(NamedTuple):
@@ -84,13 +99,14 @@ def escape(txt: str) -> str:
     return txt  # noqa:RET504
 
 
-def ansi_escape(code: str) -> str:
-    """Escape ``code`` while turning ANSI color sequences into HTML spans.
+def ansi_escape(
+    code: str,
+    scheme: str = DEFAULT_ANSI_SCHEME,
+    dark_bg: bool = True,
+) -> str:
+    """Escape ``code``, turning ANSI color sequences into HTML spans.
 
-    Each line is converted independently so color spans are always balanced
-    within a line (termynal renders every output line as its own element).
-    Literal text is HTML-escaped by ``ansi2html`` itself, so the result is a
-    drop-in replacement for :func:`escape` when ANSI support is enabled.
+    Converted per line so spans stay balanced within each terminal line.
     """
     try:
         from ansi2html import Ansi2HTMLConverter
@@ -100,7 +116,7 @@ def ansi_escape(code: str) -> str:
             "Install it with: pip install 'termynal[ansi]'",
         ) from exc
 
-    converter = Ansi2HTMLConverter(inline=True)
+    converter = Ansi2HTMLConverter(inline=True, scheme=scheme, dark_bg=dark_bg)
     return "\n".join(
         converter.convert(line, full=False) for line in code.split("\n")
     )
@@ -168,6 +184,16 @@ def parse_config_from_dict(
     if not isinstance(ansi, bool):
         ansi = ansi_default
 
+    ansi_scheme_default = default.ansi_scheme if default else DEFAULT_ANSI_SCHEME
+    ansi_scheme = config.get("ansi_scheme", ansi_scheme_default)
+    if ansi_scheme not in ANSI_SCHEMES:
+        ansi_scheme = ansi_scheme_default
+
+    ansi_dark_bg_default = default.ansi_dark_bg if default else True
+    ansi_dark_bg = config.get("ansi_dark_bg", ansi_dark_bg_default)
+    if not isinstance(ansi_dark_bg, bool):
+        ansi_dark_bg = ansi_dark_bg_default
+
     return Config(
         title=str(config.get("title", default.title if default else "bash")),
         prompt_literal_start=list(
@@ -181,6 +207,8 @@ def parse_config_from_dict(
         assets_override_css=assets_override_css,
         assets_override_js=assets_override_js,
         ansi=ansi,
+        ansi_scheme=ansi_scheme,
+        ansi_dark_bg=ansi_dark_bg,
     )
 
 
@@ -349,11 +377,17 @@ class TermynalPreprocessor(Preprocessor):
                     if config:
                         termynal = Termynal(config)
 
-                escaper = ansi_escape if termynal.config.ansi else escape
-                converted_code = add_spaces(
-                    termynal.convert(escaper(remove_spaces(code, spaces))),
-                    spaces,
+                cleaned = remove_spaces(code, spaces)
+                escaped = (
+                    ansi_escape(
+                        cleaned,
+                        termynal.config.ansi_scheme,
+                        termynal.config.ansi_dark_bg,
+                    )
+                    if termynal.config.ansi
+                    else escape(cleaned)
                 )
+                converted_code = add_spaces(termynal.convert(escaped), spaces)
                 text = f"{text[:start]}\n{converted_code}\n{text[end:]}"
                 termynal = default_termynal
             else:
@@ -403,6 +437,16 @@ class TermynalExtension(Extension):
                 "Convert ANSI color sequences (e.g. from rich/typer output) into "
                 "HTML spans instead of escaping them. Requires the 'ansi2html' "
                 "package. Default: False",
+            ],
+            "ansi_scheme": [
+                DEFAULT_ANSI_SCHEME,
+                "Palette for the 16 base ANSI colors when ansi is enabled. One of: "
+                f"{', '.join(ANSI_SCHEMES)}. Default: '{DEFAULT_ANSI_SCHEME}'",
+            ],
+            "ansi_dark_bg": [
+                True,
+                "Use the dark-background palette variant when ansi is enabled. "
+                "Default: True",
             ],
         }
 

--- a/termynal/plugin.py
+++ b/termynal/plugin.py
@@ -19,6 +19,7 @@ class TermynalPluginConfig(base.Config):
     include_assets = c.Type(bool, default=False)
     assets_override_css = c.Optional(c.Type(str))
     assets_override_js = c.Optional(c.Type(str))
+    ansi = c.Type(bool, default=False)
 
 
 class TermynalPlugin(BasePlugin[TermynalPluginConfig]):

--- a/termynal/plugin.py
+++ b/termynal/plugin.py
@@ -20,6 +20,20 @@ class TermynalPluginConfig(base.Config):
     assets_override_css = c.Optional(c.Type(str))
     assets_override_js = c.Optional(c.Type(str))
     ansi = c.Type(bool, default=False)
+    ansi_scheme = c.Choice(
+        (
+            "ansi2html",
+            "dracula",
+            "mint-terminal",
+            "osx",
+            "osx-basic",
+            "osx-solid-colors",
+            "solarized",
+            "xterm",
+        ),
+        default="xterm",
+    )
+    ansi_dark_bg = c.Type(bool, default=True)
 
 
 class TermynalPlugin(BasePlugin[TermynalPluginConfig]):

--- a/termynal/plugin.py
+++ b/termynal/plugin.py
@@ -6,6 +6,8 @@ from mkdocs.config import base
 from mkdocs.config import config_options as c
 from mkdocs.plugins import BasePlugin
 
+from termynal.markdown import ANSI_SCHEMES, DEFAULT_ANSI_SCHEME
+
 if TYPE_CHECKING:  # pragma:no cover
     from mkdocs.config.defaults import MkDocsConfig
 
@@ -20,19 +22,7 @@ class TermynalPluginConfig(base.Config):
     assets_override_css = c.Optional(c.Type(str))
     assets_override_js = c.Optional(c.Type(str))
     ansi = c.Type(bool, default=False)
-    ansi_scheme = c.Choice(
-        (
-            "ansi2html",
-            "dracula",
-            "mint-terminal",
-            "osx",
-            "osx-basic",
-            "osx-solid-colors",
-            "solarized",
-            "xterm",
-        ),
-        default="xterm",
-    )
+    ansi_scheme = c.Choice(ANSI_SCHEMES, default=DEFAULT_ANSI_SCHEME)
     ansi_dark_bg = c.Type(bool, default=True)
 
 

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -1,4 +1,5 @@
 # pylint:disable=invalid-name
+import os
 import sys
 
 import pytest
@@ -12,6 +13,12 @@ from termynal.markdown import TermynalExtension
 ANSI_SNIPPET = (
     "import sys; "
     r"sys.stdout.write('\x1b[31mred\x1b[0m and \x1b[32mgreen\x1b[0m\n')"
+)
+
+# Emits ANSI only when stdout is a real terminal, so it tells pty from pipe.
+ISATTY_SNIPPET = (
+    "import sys; "
+    r"sys.stdout.write('\x1b[31mred\x1b[0m\n' if sys.stdout.isatty() else 'plain\n')"
 )
 
 
@@ -29,12 +36,26 @@ def test_run_command_merges_stderr_by_default():
 
 
 def test_run_command_can_drop_stderr():
+    # merge_stderr only applies to the pipe path; a pty interleaves streams.
     out = run_command(
         [sys.executable, "-c", "import sys; print('out'); print('err', file=sys.stderr)"],
         merge_stderr=False,
+        use_pty=False,
     )
     assert "out" in out
     assert "err" not in out
+
+
+@pytest.mark.skipif(os.name != "posix", reason="pty is POSIX-only")
+def test_color_uses_pty_by_default_on_posix():
+    # No use_pty argument: color capture should auto-enable the pty.
+    out = run_command([sys.executable, "-c", ISATTY_SNIPPET])
+    assert "\x1b[31m" in out
+
+
+def test_no_pty_falls_back_to_pipe():
+    out = run_command([sys.executable, "-c", ISATTY_SNIPPET], use_pty=False)
+    assert out.strip() == "plain"
 
 
 def test_run_command_times_out():

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -1,0 +1,80 @@
+# pylint:disable=invalid-name
+import sys
+
+import pytest
+from markdown import markdown
+
+from termynal.exec import render, run_command, to_termynal_block
+from termynal.markdown import TermynalExtension
+
+# A tiny program that prints red + green via ANSI, independent of FORCE_COLOR so
+# the assertions stay deterministic across environments.
+ANSI_SNIPPET = (
+    "import sys; "
+    r"sys.stdout.write('\x1b[31mred\x1b[0m and \x1b[32mgreen\x1b[0m\n')"
+)
+
+
+def test_run_command_captures_stdout():
+    out = run_command([sys.executable, "-c", "print('hello world')"])
+    assert out.strip() == "hello world"
+
+
+def test_run_command_merges_stderr_by_default():
+    out = run_command(
+        [sys.executable, "-c", "import sys; print('out'); print('err', file=sys.stderr)"],
+    )
+    assert "out" in out
+    assert "err" in out
+
+
+def test_run_command_can_drop_stderr():
+    out = run_command(
+        [sys.executable, "-c", "import sys; print('out'); print('err', file=sys.stderr)"],
+        merge_stderr=False,
+    )
+    assert "out" in out
+    assert "err" not in out
+
+
+def test_run_command_times_out():
+    with pytest.raises(Exception):  # noqa: B017,PT011 - TimeoutExpired
+        run_command([sys.executable, "-c", "import time; time.sleep(5)"], timeout=0.5)
+
+
+def test_to_termynal_block_single_ansi_key_uses_plain_form():
+    block = to_termynal_block("mytool --help", "output line")
+    assert block.startswith("<!-- termynal: ansi: true -->\n")
+    assert "$ mytool --help" in block
+    assert "output line" in block
+
+
+def test_to_termynal_block_multiple_keys_use_inline_yaml():
+    block = to_termynal_block("mytool", "out", title="demo")
+    assert block.startswith("<!-- termynal: {ansi: true, title: demo} -->\n")
+
+
+def test_to_termynal_block_without_ansi():
+    block = to_termynal_block("mytool", "out", ansi=False)
+    assert block.startswith("<!-- termynal -->\n")
+
+
+def test_to_termynal_block_normalizes_crlf_and_trailing_newlines():
+    block = to_termynal_block("c", "a\r\nb\n\n")
+    body = block.split("```\n", 1)[1].rsplit("\n```", 1)[0]
+    assert body == "$ c\na\nb"
+
+
+def test_render_round_trips_through_termynal():
+    block = render([sys.executable, "-c", ANSI_SNIPPET], title="demo")
+    html = markdown(block, extensions=["fenced_code", TermynalExtension(ansi=True)])
+    assert 'data-ty="input"' in html
+    assert '<span style="color: #cd0000">red</span>' in html
+    assert '<span style="color: #00cd00">green</span>' in html
+    assert html.count("<span") == html.count("</span>")
+
+
+def test_render_command_display_defaults_to_quoted_command():
+    block = render([sys.executable, "-c", "print(1)"], title=None)
+    # shlex.join quotes the snippet so the input line is copy-pasteable.
+    assert f"$ {sys.executable}" in block

--- a/tests/test_markdown_extension.py
+++ b/tests/test_markdown_extension.py
@@ -105,3 +105,35 @@ $ echo termynal
     assert ".termy { border: 1px solid red; }" in html
     assert "window.__termynal_override = true;" in html
     assert "data-terminal-control" not in html
+
+
+def test_ansi_output_is_converted_to_spans():
+    md = "<!-- termynal -->\n```\n$ run\n\x1b[31mred\x1b[0m line\n```\n"
+    html = markdown(
+        md,
+        extensions=["fenced_code", TermynalExtension(ansi=True)],
+    )
+    assert '<span style="color: #aa0000">red</span> line' in html
+    # The command line stays a normal termynal input.
+    assert '<span data-ty="input" data-ty-prompt="$">run</span>' in html
+
+
+def test_ansi_disabled_keeps_escape_codes_literal():
+    md = "<!-- termynal -->\n```\n\x1b[31mred\x1b[0m line\n```\n"
+    html = markdown(
+        md,
+        extensions=["fenced_code", TermynalExtension()],
+    )
+    assert "color: #aa0000" not in html
+
+
+def test_ansi_per_block_override():
+    md = (
+        "<!-- termynal: ansi: true -->\n"
+        "```\n$ run\n\x1b[32mgreen\x1b[0m\n```\n"
+    )
+    html = markdown(
+        md,
+        extensions=["fenced_code", TermynalExtension()],
+    )
+    assert "color: #00aa00" in html

--- a/tests/test_markdown_extension.py
+++ b/tests/test_markdown_extension.py
@@ -126,6 +126,24 @@ def test_ansi_disabled_keeps_escape_codes_literal():
     assert "color: #aa0000" not in html
 
 
+@pytest.mark.parametrize(
+    "line",
+    [
+        "\x1b[31mno reset",
+        "\x1b[ broken \x1b[0m",
+        "\x1b[2J\x1b[1;1Hcursor codes",
+        "carriage\rreturn",
+        "\x1b[7mreverse\x1b[0m",
+        "abc\x08\x08\x1b[32mxy\x1b[0m",
+    ],
+    ids=["no-reset", "broken", "cursor-codes", "carriage-return", "reverse", "backspace"],
+)
+def test_ansi_handles_malformed_input_without_raising(line: str):
+    md = "<!-- termynal: ansi: true -->\n```\n" + line + "\n```\n"
+    html = markdown(md, extensions=["fenced_code", TermynalExtension(ansi=True)])
+    assert html.count("<span") == html.count("</span>")
+
+
 def test_ansi_does_not_alter_ansi_free_output():
     md = "<!-- termynal -->\n```\n$ echo hi\nplain \"quoted\" & <stuff>\n```\n"
     off = markdown(md, extensions=["fenced_code", TermynalExtension(ansi=False)])

--- a/tests/test_markdown_extension.py
+++ b/tests/test_markdown_extension.py
@@ -113,8 +113,7 @@ def test_ansi_output_is_converted_to_spans():
         md,
         extensions=["fenced_code", TermynalExtension(ansi=True)],
     )
-    assert '<span style="color: #aa0000">red</span> line' in html
-    # The command line stays a normal termynal input.
+    assert '<span style="color: #cd0000">red</span> line' in html
     assert '<span data-ty="input" data-ty-prompt="$">run</span>' in html
 
 
@@ -127,6 +126,33 @@ def test_ansi_disabled_keeps_escape_codes_literal():
     assert "color: #aa0000" not in html
 
 
+def test_ansi_default_scheme_is_xterm():
+    md = "<!-- termynal -->\n```\n\x1b[31mred\x1b[0m\n```\n"
+    html = markdown(md, extensions=["fenced_code", TermynalExtension(ansi=True)])
+    assert "color: #cd0000" in html
+
+
+def test_ansi_scheme_override():
+    md = "<!-- termynal -->\n```\n\x1b[31mred\x1b[0m\n```\n"
+    html = markdown(
+        md,
+        extensions=["fenced_code", TermynalExtension(ansi=True, ansi_scheme="osx")],
+    )
+    assert "color: #c23621" in html
+
+
+def test_ansi_invalid_scheme_falls_back_to_default():
+    md = "<!-- termynal -->\n```\n\x1b[31mred\x1b[0m\n```\n"
+    html = markdown(
+        md,
+        extensions=[
+            "fenced_code",
+            TermynalExtension(ansi=True, ansi_scheme="not-a-scheme"),
+        ],
+    )
+    assert "color: #cd0000" in html
+
+
 def test_ansi_per_block_override():
     md = (
         "<!-- termynal: ansi: true -->\n"
@@ -136,4 +162,4 @@ def test_ansi_per_block_override():
         md,
         extensions=["fenced_code", TermynalExtension()],
     )
-    assert "color: #00aa00" in html
+    assert "color: #00cd00" in html

--- a/tests/test_markdown_extension.py
+++ b/tests/test_markdown_extension.py
@@ -126,6 +126,13 @@ def test_ansi_disabled_keeps_escape_codes_literal():
     assert "color: #aa0000" not in html
 
 
+def test_ansi_does_not_alter_ansi_free_output():
+    md = "<!-- termynal -->\n```\n$ echo hi\nplain \"quoted\" & <stuff>\n```\n"
+    off = markdown(md, extensions=["fenced_code", TermynalExtension(ansi=False)])
+    on = markdown(md, extensions=["fenced_code", TermynalExtension(ansi=True)])
+    assert off == on
+
+
 def test_ansi_default_scheme_is_xterm():
     md = "<!-- termynal -->\n```\n\x1b[31mred\x1b[0m\n```\n"
     html = markdown(md, extensions=["fenced_code", TermynalExtension(ansi=True)])

--- a/uv.lock
+++ b/uv.lock
@@ -934,6 +934,7 @@ dev = [
     { name = "types-pyyaml" },
 ]
 docs = [
+    { name = "ansi2html" },
     { name = "markdown-include" },
     { name = "mkdocs" },
     { name = "mkdocs-material" },
@@ -966,6 +967,7 @@ dev = [
     { name = "types-pyyaml", specifier = ">=6.0" },
 ]
 docs = [
+    { name = "ansi2html", specifier = ">=1.8" },
     { name = "markdown-include", specifier = ">=0.8" },
     { name = "mkdocs", specifier = ">=1.6" },
     { name = "mkdocs-material", specifier = ">=9.5" },

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "ansi2html"
+version = "1.9.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/d5/e3546dcd5e4a9566f4ed8708df5853e83ca627461a5b048a861c6f8e7a26/ansi2html-1.9.2.tar.gz", hash = "sha256:3453bf87535d37b827b05245faaa756dbab4ec3d69925e352b6319c3c955c0a5", size = 44300, upload-time = "2024-06-22T17:33:23.964Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/71/aee71b836e9ee2741d5694b80d74bfc7c8cd5dbdf7a9f3035fcf80d792b1/ansi2html-1.9.2-py3-none-any.whl", hash = "sha256:dccb75aa95fb018e5d299be2b45f802952377abfdce0504c17a6ee6ef0a420c5", size = 17614, upload-time = "2024-06-22T17:33:21.852Z" },
+]
+
+[[package]]
 name = "argcomplete"
 version = "3.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -897,19 +906,23 @@ wheels = [
 
 [[package]]
 name = "termynal"
-version = "0.13.1"
+version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "markdown" },
 ]
 
 [package.optional-dependencies]
+ansi = [
+    { name = "ansi2html" },
+]
 mkdocs = [
     { name = "mkdocs" },
 ]
 
 [package.dev-dependencies]
 dev = [
+    { name = "ansi2html" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -933,13 +946,15 @@ git = [
 
 [package.metadata]
 requires-dist = [
+    { name = "ansi2html", marker = "extra == 'ansi'", specifier = ">=1.8" },
     { name = "markdown", specifier = ">=3" },
     { name = "mkdocs", marker = "extra == 'mkdocs'", specifier = ">=1.4" },
 ]
-provides-extras = ["mkdocs"]
+provides-extras = ["mkdocs", "ansi"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "ansi2html", specifier = ">=1.8" },
     { name = "mypy", specifier = ">=1.13.0" },
     { name = "pytest", specifier = ">=7.4" },
     { name = "pytest-cov", specifier = ">=4.1" },


### PR DESCRIPTION
> **Stacked on #36** (ANSI colored output). Please review/merge #36 first.
> This branch is built on top of `feat/ansi-color-output`, so until #36 lands
> the diff below also contains #36's commits. The only commit that belongs to
> *this* PR is the last one (`termynal.exec` helper); once #36 merges into
> `main`, this diff collapses to just that change.

## What this PR adds (on top of #36)

A standalone authoring helper, `termynal/exec.py`, that runs a command and prints a termynal-ready, optionally colored Markdown block:

```
$ python -m termynal.exec "mytool --help" --title mytool
<!-- termynal: {ansi: true, title: mytool} -->
```

termynal's renderer stays a pure text-to-HTML transform — execution lives in this explicit step you run yourself (locally, pre-commit, or CI), never inside `mkdocs build`.

### Design

- **Stdlib-only, no new dependencies.** Uses `argparse`/`subprocess`, not typer/click. The command it runs is *your own* tool, already present in your docs environment. Rendering the captured ANSI still uses the existing `[ansi]` extra from #36.
- **Stops at termynal-ready Markdown**, not HTML — one ANSI converter, one set of color schemes, and the typing animation is preserved for free.
- Forces color via `FORCE_COLOR=1` (rich/typer/click) with a `--pty` fallback for CLIs that check `isatty` (POSIX); pins `COLUMNS` for reproducible wrapping.

### Tests

`tests/test_exec.py` — 10 tests: capture, stderr merge/drop, timeout, the three comment-header forms, CRLF normalization, and an end-to-end round-trip through `TermynalExtension(ansi=True)` asserting balanced red+green spans. Full suite: 47 passed, ruff clean.

### Known sharp edge

Captured output lines starting with `$ ` or `# ` would be parsed by termynal as a prompt/comment. Rare in `--help` output; left unguarded rather than over-engineered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)